### PR TITLE
Fix missing borrow in pathext comparison

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -155,7 +155,7 @@ impl Finder {
                     .map(|pathext| {
                         pathext.split(';')
                             .filter_map(|s| {
-                                if s.as_bytes().first() == Some(b'.') {
+                                if s.as_bytes().first() == Some(&b'.') {
                                     Some(s.to_owned())
                                 } else {
                                     // Invalid segment; just ignore it.


### PR DESCRIPTION
Our Windows CI broke just after 4.2.3 released, due to 67652769a6a1013e1d6ba9084b36cabb30ca4aad:

    error[E0308]: mismatched types
       --> C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\which-4.2.3\src\finder.rs:161:65
        |
    161 | ...                   if s.as_bytes().first() == Some(b'.') {
        |                                                       ^^^^
        |                                                       |
        |                                                       expected `&u8`, found `u8`
        |                                                       help: consider borrowing here: `&b'.'`